### PR TITLE
Fix Android IPv4 and IPv6 FQDN display

### DIFF
--- a/android-app/src/main/java/at/alladin/nettest/nntool/android/app/workflow/measurement/SubMeasurementResultParseUtil.java
+++ b/android-app/src/main/java/at/alladin/nettest/nntool/android/app/workflow/measurement/SubMeasurementResultParseUtil.java
@@ -57,7 +57,7 @@ public class SubMeasurementResultParseUtil {
         ret.setRttInfo(rttInfoDto);
 
         if (speedTaskDesc != null) {
-            connectionInfoDto.setAddress(speedTaskDesc.getSpeedServerAddrV4());
+            connectionInfoDto.setAddress(speedTaskDesc.getSpeedServerAddrDefault());
             connectionInfoDto.setPort(speedTaskDesc.getSpeedServerPort());
             connectionInfoDto.setEncrypted(speedTaskDesc.isUseEncryption());
             connectionInfoDto.setRequestedNumStreamsDownload(speedTaskDesc.getDownloadStreams());


### PR DESCRIPTION
Fix Android IPv4 and IPv6 FQDN display to correctly show the chosen IP version.