### PR TITLE
Fix ias-server config.json

### DIFF
--- a/docs/load_balancing_service.adoc
+++ b/docs/load_balancing_service.adoc
@@ -21,9 +21,9 @@ The following options are available:
 |string
 |`eth1`
 |Interface which should be monitored for rx and tx rates
-|`bandwidth_bps`
+|`bandwidth`
 |object
-|`{"max":1000000000, "free":200000000}`
+|`{"bits_max":1000000000, "bits_free":200000000}`
 |Maximum capacity in bits per second of monitored interface, and overload threshold of minimum free capacity in rx and tx directions  
 |===
 

--- a/ias-server/config.json
+++ b/ias-server/config.json
@@ -22,9 +22,9 @@
     "monitoring": {
       "enabled": true,
       "interface": "eth1",
-      "bandwidth_bps": {
-        "max": 1000000000,
-        "free": 200000000
+      "bandwidth": {
+        "bits_max": 1000000000,
+        "bits_free": 200000000
       }
     },
     "balancer": {

--- a/ias-server/test_files/config.json
+++ b/ias-server/test_files/config.json
@@ -22,9 +22,9 @@
     "monitoring": {
       "enabled": true,
       "interface": "lo",
-      "bandwidth_bps": {
-        "max": 1000000000,
-        "free": 200000000
+      "bandwidth": {
+        "bits_max": 1000000000,
+        "bits_free": 200000000
       }
     },
     "balancer": {


### PR DESCRIPTION
Config.json in ias-server does state outdated load monitoring parameters, and therefore uses defaults in all cases.